### PR TITLE
Optionally create ~/.fcs directory for settings on first run.

### DIFF
--- a/build/scripts-3.7/fcs
+++ b/build/scripts-3.7/fcs
@@ -257,7 +257,6 @@ if first_run:
         os.mkdir(HOME_DIR)
     else:
         print('Attempting to use {} instead'.format(SCRIPT_DIR))
-        BASE_DIR_PATH = SCRIPT_DIR
 
 if os.path.exists(HOME_DIR):
     BASE_DIR_PATH = HOME_DIR

--- a/build/scripts-3.7/fcs
+++ b/build/scripts-3.7/fcs
@@ -271,9 +271,9 @@ try:
 except:
     RING_DIR = None
 
-TOPIC_SHELF_FILE_PATH = os.path.join(BASE_DIR_PATH, 'fptopicsc')
+TOPIC_SHELF_FILE_PATH = os.path.join(BASE_DIR_PATH, FILE_NAME_TOPICS)
 
-TAG_SHELF_FILE_PATH = os.path.join(BASE_DIR_PATH, 'fptags')
+TAG_SHELF_FILE_PATH = os.path.join(BASE_DIR_PATH, FILE_NAME_TAGS)
 
 LOG_PATH = os.path.join(BASE_DIR_PATH, 'fplog.csv')
 

--- a/build/scripts-3.7/fcs
+++ b/build/scripts-3.7/fcs
@@ -241,7 +241,28 @@ import webbrowser
 import platform
 from pkg_resources import resource_filename
 
-BASE_DIR_PATH = os.path.dirname(os.path.abspath(__file__))
+FILE_NAME_TOPICS = 'fptopicsc'
+FILE_NAME_TAGS = 'fptags'
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+HOME_DIR = os.path.join(os.path.expanduser('~'), '.fcs')
+
+first_run = (not os.path.exists(os.path.join(SCRIPT_DIR, FILE_NAME_TOPICS))
+    and not os.path.exists(HOME_DIR))
+
+if first_run:
+    choice = input('OK to create a directory at {home}? (Y/n)'.format(home=HOME_DIR))
+    if choice == 'Y' or choice == 'y' or choice == '':
+        print('Initializing directory...')
+        os.mkdir(HOME_DIR)
+    else:
+        print('Attempting to use {} instead'.format(SCRIPT_DIR))
+        BASE_DIR_PATH = SCRIPT_DIR
+
+if os.path.exists(HOME_DIR):
+    BASE_DIR_PATH = HOME_DIR
+else:
+    BASE_DIR_PATH = SCRIPT_DIR
 
 # RING_DIR = os.path.join(BASE_DIR_PATH, 'rings/')
 


### PR DESCRIPTION
When `fcs` is first run, ask the user if they would like to create a directory at `~/.fcs` for their `fptopicsc` and `fptags` files.  This solves permissions issues when `fcs` is installed to a directory that the user does not have write access to (which is the case on many Linux systems).

If the user selects `n` at the prompt, `fcs` will fall back to the original behavior of creating topic/tags files in the same directory as the `fcs` script.